### PR TITLE
Added a "verbose" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ isFastNet((value) => {
 timesToTest: 5, // optional, number of times to load the image default is 5
 threshold: 200, // optional, threshold in ms after which internet speed is considered slow
 image:  "http://www.google.com/images/phd/px.gif", //  optional, url of the tiny image to load
-allowEarlyExit: true // optional, if the first request takes greater than threshold*3 ms then the function exits with false
+allowEarlyExit: true, // optional, if the first request takes greater than threshold*3 ms then the function exits with false
 verbose: false  // optional, if set, it returns an object with all calculated latency data. Overrides allowEarlyExit option (See Example #2 for usage)
 })
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Built on top of [this Stack Overflow answer](https://stackoverflow.com/a/21372151/6513036).
 
-## Example
+## Example 1
 ```html
 <script src="https://cdn.jsdelivr.net/npm/isfastnet"></script>
 <script>
@@ -9,6 +9,24 @@ Built on top of [this Stack Overflow answer](https://stackoverflow.com/a/2137215
         let speed = value ? 'fast':'slow';
         console.log('Internet is ' + speed);
     })
+</script>
+```
+
+## Example 2 (Verbose)
+```html
+<script src="https://cdn.jsdelivr.net/npm/isfastnet"></script>
+<script>
+    isFastNet((data) => {
+        /**
+        * data = {
+        *   "isFast": Boolean,
+        *   "averageLatency": Number,
+        *   "threshold": Number,
+        *   "latencyReadings": [Number]
+        * } 
+        */
+        console.log('Received latency data: ' + JSON.stringify(data));
+    }, { verbose: true })
 </script>
 ```
 
@@ -26,6 +44,7 @@ timesToTest: 5, // optional, number of times to load the image default is 5
 threshold: 200, // optional, threshold in ms after which internet speed is considered slow
 image:  "http://www.google.com/images/phd/px.gif", //  optional, url of the tiny image to load
 allowEarlyExit: true // optional, if the first request takes greater than threshold*3 ms then the function exits with false
+verbose: false  // optional, if set, it returns an object with all calculated latency data. Overrides allowEarlyExit option (See Example #2 for usage)
 })
 
 ```

--- a/isfastnet.js
+++ b/isfastnet.js
@@ -4,18 +4,29 @@ function isFastNet(callback, options = {}){
         timesToTest: 5,
         threshold: 200,
         image:  "https://www.google.com/images/phd/px.gif",
-        allowEarlyExit: true
+        allowEarlyExit: true,
+        verbose: false
     }
 
     Object.assign(_options, options);
+
+    //If verbose option is set, force allowEarlyExit to be false
+    if(_options.verbose) {
+      _options.allowEarlyExit = false;
+    }
 
     let arrTimes = [];
     let i = 0;
     let dummyImage = new Image();
     let isDismissed = false;
     
-    testLatency(function(avg){
-        callback((avg <= _options.threshold))
+    testLatency(function(avgInfo){
+      if (_options.verbose) {
+        avgInfo["isFast"] = (avgInfo.averageLatency <= _options.threshold)
+        callback(avgInfo); 
+      } else {
+        callback((avgInfo <= _options.threshold))
+      }
     });
     
     // Recursively get average latency
@@ -46,7 +57,16 @@ function isFastNet(callback, options = {}){
         let sum = arrTimes.reduce(function(a, b) { return a + b; });
         let avg = sum / arrTimes.length;
         if(!isDismissed){
+          if(_options.verbose) {
+            let objectToReturn = {
+              "averageLatency": avg,
+              "threshold": _options.threshold,
+              "latencyReadings": arrTimes
+            }
+            cb(objectToReturn);
+          } else {
             cb(avg);
+          }
         }
       }
     }


### PR DESCRIPTION
If set, the script will return an object containing all calculated latency data.
The "verbose" option overrides "allowEarlyExit" option.
Currently; average latency (Number), threshold (Number), all latency readings (Array of Numbers) are returned, in addition to a Boolean "isFast".
"isFast" is equivalent to the value retuned by the script when the verbose option is set to false.
Updated readme.md with an example for the usage of the flag.
Tested on local setup.

For the enhancement suggested in #1 